### PR TITLE
Configure Github action to build CSS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,22 @@
+name: Build CSS # TODO: and deploy to Pressable
+
+on:
+  # Triggers the workflow on push events to the main branch
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # Checks-out the repository and enables nodejs
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+      
+      - name: Install npm dependencies
+        run:  npm ci
+        
+      - name: Compile SCSS
+        run: npm run compile:css
+
+      # TODO: deploy the compiled theme to Pressable

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "scripts": {
     "watch": "node-sass sass/ -o ./ --source-map true --output-style expanded --indent-type tab --indent-width 1 -w",
-    "compile:css": "node-sass sass/ -o ./ && stylelint '*.css' --fix || true && stylelint '*.css' --fix",
+    "compile:css": "node-sass sass/ -o ./",
     "compile:rtl": "rtlcss style.css style-rtl.css",
     "lint:scss": "wp-scripts lint-style 'sass/**/*.scss'",
     "lint:js": "wp-scripts lint-js 'js/*.js'",


### PR DESCRIPTION
This PR sets up a Github action to build the CSS when a new commit is pushed to `main`. Currently, the action does not do anything with the compiled CSS file. It can be extended to deploy the theme to Pressable.