### PR TITLE
try adding copy flag to lftp command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
           command: npm run compile:css
       - run:
           name: Send Via SFTP
-          command: lftp sftp://USERNAME:PASSWORD@sftp.pressable.com -e "mirror -v -R --exclude .git/ --exclude .circleci/ ./ ./htdocs/wp-content/themes/${THEME}; quit"
+          command: lftp -c sftp://USERNAME:PASSWORD@sftp.pressable.com -e "mirror -v -R --exclude .git/ --exclude .circleci/ ./ ./htdocs/wp-content/themes/${THEME}; quit"
 
 workflows:
   build-workflow:


### PR DESCRIPTION
It looks like the script is trying to `mkdir` for our sftp path instead of just copying the files up. Hoping adding the `-c` (copy) flag to the `lftp` command will be the fix.